### PR TITLE
Rebuild for python 3.14

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -24,6 +24,10 @@ jobs:
         CONFIG: osx_64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+      osx_64_python3.14.____cp314:
+        CONFIG: osx_64_python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -20,6 +20,9 @@ jobs:
       win_64_python3.13.____cp313:
         CONFIG: win_64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+      win_64_python3.14.____cp314:
+        CONFIG: win_64_python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -1,0 +1,22 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- linux-64

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -1,0 +1,26 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- osx-64

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- win-64

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -42,6 +42,11 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_64_python3.14.____cp314
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
     steps:
 
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15697&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/unicorn-binance-rest-api-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15697&branchName=main">
@@ -93,6 +100,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15697&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/unicorn-binance-rest-api-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15697&branchName=main">
@@ -118,6 +132,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15697&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/unicorn-binance-rest-api-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15697&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/unicorn-binance-rest-api-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 20facae9fbff75ffe9690b10c699411d52fae4bdacff5c4d1d4b5324c1c7b433
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Manual python 3.14 migration since the autotick-bot did not pick up issue #27 (filed 2026-04-18, two weeks ago).

## Changes
- Add `linux_64` / `osx_64` / `win_64` `cp314` ci_support files matching the global `python314` migrator (`3.14.* *_cp314`).
- Bump build number `0` → `1`.
- Add corresponding matrix entries in `.github/workflows/conda-build.yml`, `.azure-pipelines/azure-pipelines-osx.yml`, `.azure-pipelines/azure-pipelines-win.yml` and the README build status table.

## Dependency check
All run/host deps support py3.14:
- compiled: `cython`, `mypy`, `ujson`, `regex`, `cryptography` — all have `py314` builds on conda-forge
- noarch: `certifi`, `colorama`, `dateparser`, `pyopenssl`, `pysocks`, `requests`, `service_identity`

## Notes
The previous py3.14 PR (#22) was closed in noarch days; the feedstock has since switched to a compiled build (#23). Files were derived from the existing py3.13 ci_support files plus the python314 migrator pattern. A proper rerender by the conda-forge bot is welcome to pick up anything I missed — the next regular rerender on the next version bump will normalize this anyway.

Closes #27.